### PR TITLE
Remove double active directory reference

### DIFF
--- a/configuration/authentication/ldap-active-directory.md
+++ b/configuration/authentication/ldap-active-directory.md
@@ -14,7 +14,6 @@ spring:
     group-filter-search-base: "ou=people,dc=planetexpress,dc=com" # required for RBAC
 oauth2:
   ldap:
-    activeDirectory: false
     aсtiveDirectory:
       domain: memelord.lol
 ```


### PR DESCRIPTION
Someone simply added it twice and that doesn't seem to make sense.