### PR TITLE
Charts: Update oauth2 page to contain example of secrets injection

### DIFF
--- a/configuration/authentication/oauth2.md
+++ b/configuration/authentication/oauth2.md
@@ -29,25 +29,6 @@ auth:
           roles-field: groups # required for RBAC, a field name in OAuth token which will contain user's roles/groups
 ```
 
-### Secrets injection
-Fields like `clientId` and `clientSecret` can be passed as secret. You need to use the `existingSecret` variable with appropriate fields.
-Example:
-```yaml
-existingSecret: "kafka-ui"
-yamlApplicationConfig:
-  auth:
-    type: OAUTH2
-    oauth2:
-      client:
-        google:
-          provider: google
-          user-name-attribute: <zzz>
-          custom-params:
-            type: google
-            allowedDomain: <your_domain>
-```
-Where `existingSecret` will contain such fields as `AUTH_OAUTH2_CLIENT_GOOGLE_CLIENTID` and `AUTH_OAUTH2_CLIENT_GOOGLE_CLIENTSECRET`
-
 ## Service Discovery
 
 For specific providers like Github (non-enterprise) and Google ([see the current list](https://github.com/spring-projects/spring-security/blob/main/config/src/main/java/org/springframework/security/config/oauth2/client/CommonOAuth2Provider.java#L35)), you don't have to specify URIs as they're well known.

--- a/configuration/authentication/oauth2.md
+++ b/configuration/authentication/oauth2.md
@@ -29,6 +29,25 @@ auth:
           roles-field: groups # required for RBAC, a field name in OAuth token which will contain user's roles/groups
 ```
 
+### Secrets injection
+Fields like `clientId` and `clientSecret` can be passed as secret. You need to use the `existingSecret` variable with appropriate fields.
+Example:
+```yaml
+existingSecret: "kafka-ui"
+yamlApplicationConfig:
+  auth:
+    type: OAUTH2
+    oauth2:
+      client:
+        google:
+          provider: google
+          user-name-attribute: <zzz>
+          custom-params:
+            type: google
+            allowedDomain: <your_domain>
+```
+Where `existingSecret` will contain such fields as `AUTH_OAUTH2_CLIENT_GOOGLE_CLIENTID` and `AUTH_OAUTH2_CLIENT_GOOGLE_CLIENTSECRET`
+
 ## Service Discovery
 
 For specific providers like Github (non-enterprise) and Google ([see the current list](https://github.com/spring-projects/spring-security/blob/main/config/src/main/java/org/springframework/security/config/oauth2/client/CommonOAuth2Provider.java#L35)), you don't have to specify URIs as they're well known.

--- a/configuration/helm-charts/existing-secret-oauth.md
+++ b/configuration/helm-charts/existing-secret-oauth.md
@@ -1,0 +1,18 @@
+### Existing secret usage
+For example, in auth section you want to pass sensitive values like `clientId` and `clientSecret` as a secret to be sure that such data will not be exposed through code. `existingSecret` field will help you with it. You need to create appropriate Kubernetes Secret with same name and pass there values that you need.
+Example:
+```yaml
+existingSecret: "kafka-ui"
+yamlApplicationConfig:
+  auth:
+    type: OAUTH2
+    oauth2:
+      client:
+        google:
+          provider: google
+          user-name-attribute: <zzz>
+          custom-params:
+            type: google
+            allowedDomain: <your_domain>
+```
+Where `existingSecret` will contain such fields as `AUTH_OAUTH2_CLIENT_GOOGLE_CLIENTID` and `AUTH_OAUTH2_CLIENT_GOOGLE_CLIENTSECRET`.


### PR DESCRIPTION
When configuring kafka ui I faced a problem where I have to go through all docs to discover usage of secrets in oauth provider. I want to introduce this example so the newcomers can setup their secrets in oauth section much easier