### PR TITLE
Fix Helm Charts documentation referencing Route instead of Ingress

### DIFF
--- a/configuration/helm-charts/configuration/README.md
+++ b/configuration/helm-charts/configuration/README.md
@@ -4,23 +4,23 @@ Most of the Helm charts parameters are common, follow table describes unique par
 
 #### Kafbat-UI parameters
 
-| Parameter                                 | Description                                                                                                                                    | Default     |
-| ----------------------------------------- |------------------------------------------------------------------------------------------------------------------------------------------------| ----------- |
-| `existingConfigMap`                       | Name of the existing ConfigMap with kafbat-ui environment variables                                                                            | `nil`       |
-| `existingSecret`                          | Name of the existing Secret with Kafbat-UI environment variables                                                                                | `nil`       |
-| `envs.secret`                             | Set of the sensitive environment variables to pass to Kafbat-UI                                                                                 | `{}`        |
-| `envs.config`                             | Set of the environment variables to pass to Kafbat-UI                                                                                           | `{}`        |
-| `yamlApplicationConfigConfigMap`          | Map with name and keyName keys, name refers to the existing ConfigMap, keyName refers to the ConfigMap key with Kafbat-UI config in Yaml format | `{}`        |
-| `yamlApplicationConfig`                   | Kafbat-UI config in Yaml format                                                                                                                 | `{}`        |
-| `networkPolicy.enabled`                   | Enable network policies                                                                                                                        | `false`     |
-| `networkPolicy.egressRules.customRules`   | Custom network egress policy rules                                                                                                             | `[]`        |
-| `networkPolicy.ingressRules.customRules`  | Custom network ingress policy rules                                                                                                            | `[]`        |
-| `podLabels`                               | Extra labels for Kafbat-UI pod                                                                                                                  | `{}`        |
-| `route.enabled`                           | Enable OpenShift route to expose the Kafbat-UI service                                                                                          | `false`     |
-| `route.annotations`                       | Add annotations to the OpenShift route                                                                                                         | `{}`        |
-| `route.tls.enabled`                       | Enable OpenShift route as a secured endpoint                                                                                                   | `false`     |
-| `route.tls.termination`                   | Set OpenShift Route TLS termination                                                                                                            | `edge`      |
-| `route.tls.insecureEdgeTerminationPolicy` | Set OpenShift Route Insecure Edge Termination Policy                                                                                           | `Redirect`  |
+| Parameter                                   | Description                                                                                                                                     | Default     |
+| ------------------------------------------- |-------------------------------------------------------------------------------------------------------------------------------------------------| ----------- |
+| `existingConfigMap`                         | Name of the existing ConfigMap with kafbat-ui environment variables                                                                             | `nil`       |
+| `existingSecret`                            | Name of the existing Secret with Kafbat-UI environment variables                                                                                | `nil`       |
+| `envs.secret`                               | Set of the sensitive environment variables to pass to Kafbat-UI                                                                                 | `{}`        |
+| `envs.config`                               | Set of the environment variables to pass to Kafbat-UI                                                                                           | `{}`        |
+| `yamlApplicationConfigConfigMap`            | Map with name and keyName keys, name refers to the existing ConfigMap, keyName refers to the ConfigMap key with Kafbat-UI config in Yaml format | `{}`        |
+| `yamlApplicationConfig`                     | Kafbat-UI config in Yaml format                                                                                                                 | `{}`        |
+| `networkPolicy.enabled`                     | Enable network policies                                                                                                                        	| `false`     |
+| `networkPolicy.egressRules.customRules`     | Custom network egress policy rules                                                                                                             	| `[]`        |
+| `networkPolicy.ingressRules.customRules`    | Custom network ingress policy rules                                                                                                            	| `[]`        |
+| `podLabels`                             	  | Extra labels for Kafbat-UI pod                                                                                                                  | `{}`        |
+| `ingress.enabled`                           | Enable Ingress to expose the Kafbat-UI service                                                                                          		| `false`     |
+| `ingress.annotations`                       | Add annotations to the Ingress                                                                                                         			| `{}`        |
+| `ingress.tls.enabled`                       | Enable Ingress route as a secured endpoint                                                                                                   	| `false`     |
+| `ingress.tls.termination`                   | Set Ingress TLS termination                                                                                                            			| `edge`      |
+| `ingress.tls.insecureEdgeTerminationPolicy` | Set Ingress Insecure Edge Termination Policy                                                                                           			| `Redirect`  |
 
 ### Example
 


### PR DESCRIPTION
`Route` has been replaced by `Ingress` in the last version of the Helm Charts.