### PR TITLE
Let use helm chart readme

### DIFF
--- a/configuration/helm-charts/configuration/README.md
+++ b/configuration/helm-charts/configuration/README.md
@@ -4,23 +4,8 @@ Most of the Helm charts parameters are common, follow table describes unique par
 
 #### Kafbat-UI parameters
 
-| Parameter                                 | Description                                                                                                                                    | Default     |
-| ----------------------------------------- |------------------------------------------------------------------------------------------------------------------------------------------------| ----------- |
-| `existingConfigMap`                       | Name of the existing ConfigMap with kafbat-ui environment variables                                                                            | `nil`       |
-| `existingSecret`                          | Name of the existing Secret with Kafbat-UI environment variables                                                                                | `nil`       |
-| `envs.secret`                             | Set of the sensitive environment variables to pass to Kafbat-UI                                                                                 | `{}`        |
-| `envs.config`                             | Set of the environment variables to pass to Kafbat-UI                                                                                           | `{}`        |
-| `yamlApplicationConfigConfigMap`          | Map with name and keyName keys, name refers to the existing ConfigMap, keyName refers to the ConfigMap key with Kafbat-UI config in Yaml format | `{}`        |
-| `yamlApplicationConfig`                   | Kafbat-UI config in Yaml format                                                                                                                 | `{}`        |
-| `networkPolicy.enabled`                   | Enable network policies                                                                                                                        | `false`     |
-| `networkPolicy.egressRules.customRules`   | Custom network egress policy rules                                                                                                             | `[]`        |
-| `networkPolicy.ingressRules.customRules`  | Custom network ingress policy rules                                                                                                            | `[]`        |
-| `podLabels`                               | Extra labels for Kafbat-UI pod                                                                                                                  | `{}`        |
-| `route.enabled`                           | Enable OpenShift route to expose the Kafbat-UI service                                                                                          | `false`     |
-| `route.annotations`                       | Add annotations to the OpenShift route                                                                                                         | `{}`        |
-| `route.tls.enabled`                       | Enable OpenShift route as a secured endpoint                                                                                                   | `false`     |
-| `route.tls.termination`                   | Set OpenShift Route TLS termination                                                                                                            | `edge`      |
-| `route.tls.insecureEdgeTerminationPolicy` | Set OpenShift Route Insecure Edge Termination Policy                                                                                           | `Redirect`  |
+Please find specific paramater description in helm chart *[README.md](https://github.com/kafbat/helm-charts/blob/main/charts/kafka-ui/README.md)*
+
 
 ### Example
 


### PR DESCRIPTION
Since we moved helm chart param description to the helm repo, it is better to use the same source for params description.