### PR TITLE
Add OAuth2/OIDC authentication setup with GoAuthentic

### DIFF
--- a/configuration/authentication/oauth2.md
+++ b/configuration/authentication/oauth2.md
@@ -226,7 +226,7 @@ auth:
         client-name: goauthentic
         issuer-uri: https://<goauthentic_instance>/application/o/<slug>/
         user-name-attribute: nickname # OR "name", "given_name", "email", "preferred_username"
-        redirect-uri: http://localhost:8080/login/oauth2/code/oauth2
+        redirect-uri: http://localhost:8080/login/oauth2/code/goauthentic
         authorization-grant-type: authorization_code
         custom-params:
           type: oauth

--- a/configuration/authentication/oauth2.md
+++ b/configuration/authentication/oauth2.md
@@ -210,3 +210,26 @@ auth:
         custom-params:
           type: oauth
 ```
+
+### GoAuthentic
+
+```yaml
+auth:
+  type: OAUTH2
+  oauth2:
+    client:
+      goauthentic:
+        provider: goauthentic
+        clientId: xxx
+        clientSecret: yyy
+        scope: [ 'openid', 'profile', 'email' ]
+        client-name: goauthentic
+        issuer-uri: https://<goauthentic_instance>/application/o/<slug>/
+        user-name-attribute: nickname # OR "name", "given_name", "email", "preferred_username"
+        redirect-uri: http://localhost:8080/login/oauth2/code/oauth2
+        authorization-grant-type: authorization_code
+        custom-params:
+          type: oauth
+          roles-field: groups
+          logoutUrl: https://<goauthentic_instance>/application/o/<slug>/end-session/
+```

--- a/configuration/rbac-role-based-access-control/supported-identity-providers.md
+++ b/configuration/rbac-role-based-access-control/supported-identity-providers.md
@@ -86,7 +86,7 @@ Not yet supported, see [Issue 3741](https://github.com/kafbat/kafka-ui/issues/37
 
 You can map Okta Groups to roles. First, confirm that your okta administrator has included the `group` claim or the groups will not be passed in the auth token.
 
-Ensure `roles-field` in the auth config is set to `groups` and that `groups` is included in the `scope`, see [here](../authentication/oauth2.md###Okta) for more details.
+Ensure `roles-field` in the auth config is set to `groups` and that `groups` is included in the `scope`, see [here](../authentication/oauth2.md#okta) for more details.
 
 Configure the role mapping to the okta group via generic provider mentioned above:
 

--- a/configuration/rbac-role-based-access-control/supported-identity-providers.md
+++ b/configuration/rbac-role-based-access-control/supported-identity-providers.md
@@ -96,3 +96,18 @@ Configure the role mapping to the okta group via generic provider mentioned abov
           type: role
           value: "<okta-group-name>"
 ```
+
+### GoAuthentic
+
+You can map GoAuthentic Groups to roles. First, confirm that your GoAuthentic administrator has included the `profile` claim or the groups will not be passed in the auth token.
+
+Ensure `roles-field` in the auth config is set to `groups` and that `profile` is included in the `scope`, as groups are passed by default in the profile scope. See [here](../authentication/oauth2.md#goauthentic) for more details.
+
+Configure the role mapping to the GoAuthentic group via generic provider mentioned above:
+
+```yaml
+      subjects:
+        - provider: oauth
+          type: role
+          value: "<goauthentic-group-name>"
+```


### PR DESCRIPTION
- Add OAuth2/OIDC authentication setup with GoAuthentic and group-to-role mapping for RBAC
- Fixed Okta link in RBAC documentation