### PR TITLE
docs(rbac): Add missing connect:delete action

### DIFF
--- a/configuration/rbac-role-based-access-control/README.md
+++ b/configuration/rbac-role-based-access-control/README.md
@@ -103,7 +103,7 @@ A list of all the actions for the corresponding resources (please note neither r
 * `topic`: `view`, `create`, `edit`, `delete`, `messages_read`, `messages_produce`, `messages_delete`
 * `consumer`: `view`, `delete`, `reset_offsets`
 * `schema`: `view`, `create`, `delete`, `edit`, `modify_global_compatibility`
-* `connect`: `view`, `edit`, `create`, `restart`
+* `connect`: `view`, `edit`, `create`, `delete`,`restart`
 * `ksql`: `execute`
 * `acl`: `view`, `edit`
 


### PR DESCRIPTION
* RBAC documentation lacks(missing) mention of the `connect:delete` action.

* This can cause confusion for Kafka operators like DevOps Engineers or SREs, so we will clearly document all connect actions to prevent this.