### PR TITLE
Update quick-start.md

### DIFF
--- a/configuration/helm-charts/quick-start.md
+++ b/configuration/helm-charts/quick-start.md
@@ -83,4 +83,4 @@ data:
 
 Install by executing the command
 
-> helm install kafbat-ui charts/kafka-ui --set existingConfigMap="kafbat-ui-helm-values"
+> helm install kafbat-ui kafbat-ui/kafka-ui --set existingConfigMap="kafbat-ui-helm-values"


### PR DESCRIPTION
fix: chart name in helm installation for the existing configmap value